### PR TITLE
Update plug.gd

### DIFF
--- a/plug.gd
+++ b/plug.gd
@@ -4,4 +4,4 @@ func _plugging():
     # Declare your plugins in here with plug(src, args)
     # By default, only "addons/" directory will be installed
     plug("rakugoteam/project-settings-helpers")
-    plug("rakugoteam/Emojis-For-Godot")
+    plug("rakugoteam/Emojis-For-Godot", {"include": ["addons/", ".import/"]})


### PR DESCRIPTION
include .import configuration for emojis-for-godot so its preloaded scenes don't error out on first project load
(same PR there is in VisualNovelKit, because both projects have emojis-for-godot in gd-plug configuration)