### PR TITLE
Added "addons" folder to plug.gd configuration

### DIFF
--- a/plug.gd
+++ b/plug.gd
@@ -10,6 +10,6 @@ func _plugging():
     plug("Xrayez/godot-editor-icons-previewer")
 
     # optional supported plugins
-    plug("rakugoteam/Emojis-For-Godot", {"include": [".import/"]})
-    plug("rakugoteam/Godot-Material-Icons", {"include": [".import/"]})
+    plug("rakugoteam/Emojis-For-Godot", {"include": ["addons", ".import/"]})
+    plug("rakugoteam/Godot-Material-Icons", {"include": ["addons", ".import/"]})
   


### PR DESCRIPTION
If we add the optional `include` parameter, it will not, I think, also import the default "addons" folder unless we tell it to