### PR TITLE
Better AdvancedTextButton

### DIFF
--- a/addons/advanced-text/examples/AdvancedTextButton/AdvancedTextButton.gd
+++ b/addons/advanced-text/examples/AdvancedTextButton/AdvancedTextButton.gd
@@ -1,20 +1,48 @@
-# tool
+tool
 extends Button
 class_name AdvancedTextButton
 
-onready var adv_label := $AdvancedTextLabel
+export(String, MULTILINE) var markup_text := "" setget _set_markup_text
+export(String, "default", "markdown", "renpy", "bbcode") var markup := "default" setget _set_markup
+
+# onready var adv_label := $AdvancedTextLabel
+var adv_label : AdvancedTextLabel
+
 func _ready():
-	adv_label.connect("resized", self, "_on_button_resized")
+	if Engine.editor_hint and !adv_label:
+		adv_label = AdvancedTextLabel.new()
+		adv_label.scroll_active = false
+		adv_label.mouse_filter = MOUSE_FILTER_PASS
+		adv_label.rect_clip_content = false
+		add_child(adv_label)
+		adv_label.owner = self
+	
+	else:
+		adv_label = $AdvancedTextLabel
+	
+	_set_markup(markup)
+	_set_markup_text(markup_text)
+
 	connect("mouse_entered", self, "_on_mouse_entered")
 	connect("mouse_exited", self, "_on_mouse_exited")
 	connect("pressed", self, "_on_pressed")
 	connect("toggled", self, "_on_toggled")
 
-func set_markup_text(text: String):
+func _set_markup_text(text: String):
+	if !adv_label:
+		return
+	
 	adv_label.markup_text = text
+	yield(get_tree(), "idle_frame")
+	rect_size = adv_label.rect_size
 
-func set_markup(markup: String):
+func _set_markup(markup: String):
+	if !adv_label:
+		return
+
 	adv_label.markup = markup
+	yield(get_tree(), "idle_frame")
+	rect_size = adv_label.rect_size
 
 func _set_label_color(color_name:String):
 	adv_label.modulate = get_color(color_name, "Button")
@@ -33,9 +61,6 @@ func _set(property:String, value)->bool:
 				_set_label_color("font_color")
 				
 	return true
-
-func _on_button_resized():
-	adv_label.rect_size = rect_size
 
 func is_toggled():
 	return pressed and toggle_mode

--- a/addons/advanced-text/examples/AdvancedTextButton/AdvancedTextButton.tscn
+++ b/addons/advanced-text/examples/AdvancedTextButton/AdvancedTextButton.tscn
@@ -5,24 +5,21 @@
 [ext_resource path="res://addons/advanced-text/examples/AdvancedTextButton/AdvancedTextButton.gd" type="Script" id=3]
 
 [node name="AdvancedTextButton" type="Button"]
-margin_right = 222.0
-margin_bottom = 22.0
+margin_right = 373.0
+margin_bottom = 24.0
 rect_min_size = Vector2( 224, 24 )
 size_flags_horizontal = 3
 theme = ExtResource( 2 )
 script = ExtResource( 3 )
 
-[node name="AdvancedTextLabel" type="RichTextLabel" parent="."]
-anchor_right = 1.0
-anchor_bottom = 1.0
+[node name="RichTextLabel" type="RichTextLabel" parent="."]
+margin_right = 373.0
+margin_bottom = 20.0
+rect_clip_content = false
 mouse_filter = 1
 bbcode_enabled = true
-bbcode_text = "[center][shake rate=5 level=10][b]Advanced Text Button[/b][/shake][/center]"
-text = "Advanced Text Button"
+bbcode_text = "[center][shake rate=5 level=10][b]Advanced Teeeeeeeeeeeext Button[/b][/shake][/center]"
+text = "Advanced Teeeeeeeeeeeext Button"
 scroll_active = false
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-markup_text = "[center][shake rate=5 level=10]**Advanced Text Button**[/shake][/center]"
-markup = "markdown"
+markup_text = "[center][shake rate=5 level=10]**Advanced Teeeeeeeeeeeext Button**[/shake][/center]"


### PR DESCRIPTION
Now **AdvancedTextButton**  has to new export values: `markup_text` and `markup`.
`markup_text` and `markup` - pass those values to `markup_text` and `markup` in **AdvancedTextLabel**.
It automatically adds **AdvancedTextLabel** to it, and auto resize based on `markup_text`.