### PR TITLE
Add support to  build-in godot's translation system

### DIFF
--- a/addons/advanced-text/nodes/AdvancedTextLabel.gd
+++ b/addons/advanced-text/nodes/AdvancedTextLabel.gd
@@ -86,7 +86,7 @@ func _load_file(file_path:String) -> void:
 	f.close()
 
 func _set_markup_text(value:String) -> void:
-	markup_text = value
+	markup_text = tr(value)
 	emit_signal("update")
 
 func _on_update() -> void:


### PR DESCRIPTION
Now **AdvancedTextLabel** and also **AdvancedTextButton** that uses **AdvancedTextLabel** supports build in godot's translation system, by using `tr()` before text will be parsed.